### PR TITLE
chore(ci): Publish Docker images to Dockerhub and GHCR with attestations

### DIFF
--- a/.github/workflows/generate-package.workflow.yaml
+++ b/.github/workflows/generate-package.workflow.yaml
@@ -1,0 +1,139 @@
+name: Release and Publish Docker Image
+
+on:
+  release:
+    types: [published] # Run only when a release is published
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to deploy"
+        required: true
+
+jobs:
+  build-and-push-docker-image-to-ghcr:
+    name: "Build package to Github Container Registry"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+
+    env:
+      RESGISTRY: ghcr.io
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.RESGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release tag
+        id: extract_release_tag
+        run: |
+
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            echo "::set-output name=tag::${{ github.event.inputs.tag }}"
+          elif [[ -n "${{ github.event.release.tag_name }}" ]]; then
+            echo "::set-output name=tag::${{ github.event.release.tag_name }}"
+          else
+            echo "::error title=Tag not found::No tag found in either github.event.inputs.tag or github.event.release.tag_name"
+            exit 1 # Exit with error if no tag is found
+          fi
+
+      - name: Pushing Docker image with release tag version
+        uses: docker/build-push-action@v5.0.0
+        id: build-and-push
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.RESGISTRY }}/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.extract_release_tag.outputs.tag }}
+          push: true
+
+      - name: Pushing Docker image with 'latest' tag
+        uses: docker/build-push-action@v5.0.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.RESGISTRY }}/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+          push: true
+
+      - name: Attest artifact
+        uses: actions/attest-build-provenance@v2
+        id: attest
+        with:
+          subject-name: ${{ env.RESGISTRY }}/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true
+
+
+  # Dockerhub
+  build-and-push-docker-image-to-dockerhub:
+    name: "Build package to Dockerhub"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      RESGISTRY: ghcr.io
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io # Or registry: https://index.docker.io/v1/
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract release tag
+        id: extract_release_tag
+        run: |
+
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            echo "::set-output name=tag::${{ github.event.inputs.tag }}"
+          elif [[ -n "${{ github.event.release.tag_name }}" ]]; then
+            echo "::set-output name=tag::${{ github.event.release.tag_name }}"
+          else
+            echo "::error title=Tag not found::No tag found in either github.event.inputs.tag or github.event.release.tag_name"
+            exit 1 # Exit with error if no tag is found
+          fi
+
+      - name: Build and tag Docker image with release version
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.extract_release_tag.outputs.tag }}
+          push: true
+
+      - name: Build and tag Docker image with 'latest' tag
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
+          push: true


### PR DESCRIPTION
This commit configures the workflow to build and push Docker images to both :dockerhub and :ghcr (GitHub Container Registry). 
It also includes artifact attestations for enhanced security and provenance.

References:
- https://youtu.be/zTIHb-9c868?si=IL8859-K0DY7o4sl
- https://docs.github.com/pt/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
- https://docs.github.com/pt/actions/concepts/security/artifact-attestations